### PR TITLE
Explicitly select PP host

### DIFF
--- a/dx_app/resources/stjude/bin/generate_plot.py
+++ b/dx_app/resources/stjude/bin/generate_plot.py
@@ -135,6 +135,7 @@ if __name__ == "__main__":
 <script>
 runproteinpaint({
 	holder:document.getElementById('aaa'),
+	host:'https://proteinpaint.stjude.org',
 	parseurl:true,
 	nobox:1,
 	//block:1,


### PR DESCRIPTION
PP can autodetect host, but we should explicitly specify our host.