### PR TITLE
Rename additional output files to use the specified output_name as a prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as builder
 RUN apt-get update \
     && apt-get upgrade -y \ 
-    && apt-get --yes install \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get --yes install \
         build-essential \
         openjdk-11-jdk-headless \
         unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as builder
+FROM ubuntu:20.04 as builder
 RUN apt-get update \
     && apt-get upgrade -y \ 
     && apt-get --yes install \
@@ -18,6 +18,9 @@ ENV PATH /opt/conda/bin:$PATH
 RUN conda update -n base -c defaults conda -y && \
     conda install \
     -c conda-forge \
+    mamba
+RUN mamba install \
+    -c conda-forge \
     -c bioconda \
              r-base=3.6.1 \
              python=3.8 \
@@ -26,7 +29,7 @@ RUN conda update -n base -c defaults conda -y && \
              bioconductor-sva \
              bioconductor-deseq2 \
              scikit-learn \
-             r-tsne r-getopt r-plotly  \
+             r-tsne r-getopt r-plotly \
              pandoc -y \
     && conda clean --all -y
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/stjudecloud/expression-classification/tags). 
 
 ## License
 

--- a/dx_app/src/t-SNE.sh
+++ b/dx_app/src/t-SNE.sh
@@ -27,6 +27,8 @@ main() {
    echo "Value of gene list: '${gene_list}'"
    echo "Value of preservatives: '${preservatives}'"
 
+   output_prefix=$(basename ${output_name} ".html")
+
    local_data_dir=$HOME/in
    local_reference_dir=$HOME/reference
    local_output_dir=$HOME/out
@@ -463,7 +465,8 @@ main() {
    if [ ${#input_counts[@]} -gt 0 ]
    then
       docker run -v $local_output_dir:$container_output_dir -v /stjude/bin:/stjude/bin ghcr.io/stjudecloud/expression-classification:EXPRESSION_VERSION bash -c "cd $container_output_dir && python /stjude/bin/neighbors.py tsne.txt neighbors.tsv"
-      neighbors_file=$(dx upload $local_output_dir/neighbors.tsv --brief)
+      mv $local_output_dir/neighbors.tsv $local_output_dir/${output_prefix}.neighbors.tsv
+      neighbors_file=$(dx upload $local_output_dir/${output_prefix}.neighbors.tsv --brief)
       dx-jobutil-add-output neighbors "$neighbors_file" --class=file
    fi
 
@@ -471,17 +474,20 @@ main() {
    mv $local_output_dir/tsne_pp.html $local_output_dir/${output_name}
    tsne_plot=$(dx upload $local_output_dir/${output_name} --brief)
    dx-jobutil-add-output tsne_plot "$tsne_plot" --class=file
-   tsne_matrix=$(dx upload $local_output_dir/tsne.txt --brief)
+   mv $local_output_dir/tsne.txt $local_output_dir/${output_prefix}.tsne.txt
+   tsne_matrix=$(dx upload $local_output_dir/${output_prefix}.tsne.txt --brief)
    dx-jobutil-add-output tsne_matrix "$tsne_matrix" --class=file
    dx-jobutil-add-output trustworthiness_score "$(cat $local_output_dir/trustworthiness.txt)" --class=string
    if [ -e $local_output_dir/gene_list.txt ]
    then
+      mv $local_output_dir/gene_list.txt $local_output_dir/${output_prefix}.gene_list.txt
       gene_list=$(dx upload $local_output_dir/gene_list.txt --brief)
       dx-jobutil-add-output gene_list "$gene_list" --class=file
    fi
    if [ ${intermediate} ]
    then
-      intermediate_file=$(dx upload $local_output_dir/${intermediate}.txt --brief)
+     mv $local_output_dir/tsne.txt $local_output_dir/${output_prefix}.${intermediate}.txt
+     intermediate_file=$(dx upload $local_output_dir/${output_prefix}.${intermediate}.txt --brief)
       dx-jobutil-add-output intermediate_output "$intermediate_file" --class=file
    fi
 }

--- a/dx_app/src/t-SNE.sh
+++ b/dx_app/src/t-SNE.sh
@@ -15,6 +15,8 @@
 # See https://wiki.dnanexus.com/Developer-Portal for tutorials on how
 # to modify this file.
 
+set -e -o pipefail
+
 main() {
    echo "Value of tissue_type: '${tumor_type}'"
    echo "Value of all_strandedness: '${all_strandedness}'"
@@ -81,7 +83,7 @@ main() {
    # Setup the download location for reference counts and create the download commands
    # Download with GNU parallel
    mkdir -p $HOME/in/reference_counts/
-   echo $ids | xargs -n 1 | sed "s#^#dx download -f -o $HOME/in/reference_counts/ --no-progress #" > download_all.sh
+   echo $ids | xargs -n 1 | sed "s#^#dx download -f -o $HOME/in/reference_counts/ --no-progress ${DX_PROJECT_CONTEXT_ID}:#" > download_all.sh
    parallel --retries 20 --results download_outputs --joblog download.log < download_all.sh > download.stdout
 
    # Loop over the inputs, if any, store IDs and download in parallel

--- a/dx_app/src/t-SNE.sh
+++ b/dx_app/src/t-SNE.sh
@@ -481,7 +481,7 @@ main() {
    if [ -e $local_output_dir/gene_list.txt ]
    then
       mv $local_output_dir/gene_list.txt $local_output_dir/${output_prefix}.gene_list.txt
-      gene_list=$(dx upload $local_output_dir/gene_list.txt --brief)
+      gene_list=$(dx upload $local_output_dir/${output_prefix}.gene_list.txt --brief)
       dx-jobutil-add-output gene_list "$gene_list" --class=file
    fi
    if [ ${intermediate} ]


### PR DESCRIPTION
Additional output files use generic names like `neighbors.tsv`. That becomes confusing if a user runs the workflow multiple times. It also is problematic for users if not using a filesystem that allows identical names.