### PR TITLE
bump node size

### DIFF
--- a/dx_app/dxapp.json
+++ b/dx_app/dxapp.json
@@ -192,7 +192,7 @@
     "azure:westus": {
       "systemRequirements": {
         "*": {
-          "instanceType": "azure:mem2_ssd1_x4"
+          "instanceType": "azure:mem2_ssd1_x8"
         }
       }
     }

--- a/dx_app/dxapp.json
+++ b/dx_app/dxapp.json
@@ -192,7 +192,7 @@
     "azure:westus": {
       "systemRequirements": {
         "*": {
-          "instanceType": "azure:mem2_ssd1_x8"
+          "instanceType": "azure:mem3_ssd1_x4"
         }
       }
     }


### PR DESCRIPTION
Full cohort now exceeds RAM on smaller nodes.