### PR TITLE
fix: handle multiple JSON arrays

### DIFF
--- a/dx_app/resources/stjude/bin/bulk_describe.py
+++ b/dx_app/resources/stjude/bin/bulk_describe.py
@@ -16,7 +16,7 @@ def bulk_describe_with_id(file_links: List[str], proj_id: str) -> List:
         file_links: list of file ids (strings)
         proj_id: project id where described items is found
     Returns:
-        list of dictionary containing file infomation
+        list of dictionary containing file information
     """
 
     payload = {

--- a/dx_app/src/t-SNE.sh
+++ b/dx_app/src/t-SNE.sh
@@ -150,7 +150,8 @@ main() {
    # Get metadata in parallel for reference data
    echo "Getting metadata for all samples"
    json=$(echo $ids | xargs python3 /stjude/bin/bulk_describe.py -p $DX_PROJECT_CONTEXT_ID --ids )
-   echo $json > metadata.json
+   # Pass through jq because bulk_describe can produce multiple json arrays.
+   echo $json | jq --slurp "flatten" > metadata.json
 
    # Prepare filters
    excluded_types='germline|cell line'


### PR DESCRIPTION
For sufficiently many samples, the bulk describe script emits multiple arrays. This isn't valid JSON, so this change passes those through `jq` in order to concatenate the arrays (via the `flatten` command).